### PR TITLE
Remove 'source-map-support'

### DIFF
--- a/load-sourcemaps.js
+++ b/load-sourcemaps.js
@@ -1,1 +1,0 @@
-import 'source-map-support/register'

--- a/webpack.server.js
+++ b/webpack.server.js
@@ -12,11 +12,6 @@ const config = {
     nodeExternals()
   ],
   target: 'node',
-  entry: {
-    index: [
-      resolve(baseDirectoryPath, 'load-sourcemaps.js')
-    ]
-  },
   output: {
     path: serverDistDirectoryPath
   }


### PR DESCRIPTION
Fixes #73 

This PR removes `source-map-support` from server SDK. When using SDK with SSR (like with Next.js for example), this module produce warnings about missing Node modules on both server and client, confusing users.