### PR TITLE
Fix interface type on EstimatedShippingMethod

### DIFF
--- a/src/interfaces/EstimatedShippingMethod.ts
+++ b/src/interfaces/EstimatedShippingMethod.ts
@@ -3,7 +3,7 @@ import { ResultResponse } from './ResultResponse'
 
 export interface EstimatedShippingMethodAttr extends JsonApiDocument {
   type: 'shipping_rate',
-  id: null,
+  id: string,
   attributes: {
     name: string,
     selected: boolean,

--- a/types/interfaces/EstimatedShippingMethod.d.ts
+++ b/types/interfaces/EstimatedShippingMethod.d.ts
@@ -2,7 +2,7 @@ import { JsonApiDocument, JsonApiListResponse } from './JsonApi';
 import { ResultResponse } from './ResultResponse';
 export interface EstimatedShippingMethodAttr extends JsonApiDocument {
     type: 'shipping_rate';
-    id: null;
+    id: string;
     attributes: {
         name: string;
         selected: boolean;


### PR DESCRIPTION
## WHAT

`id` in `EstimatedShippingMethodAttr` does not match the type in the original interface, JsonApiDocument.

- JsonApiDocument: string
- EstimatedShippingMethodAttr: null

That causes a compile error in our project. (nuxt.js)

I checked [the spree api document](https://guides.spreecommerce.org/api/v2/storefront#operation/Estimate%20Shipping%20Rates) and it seems the spree api returns string value in `id` field as well.

## Related PR

- https://github.com/spree/spree-storefront-api-v2-js-sdk/pull/76