### PR TITLE
Fallback to ES2015 Error inheritance strategy

### DIFF
--- a/src/errors/BasicSpreeError.ts
+++ b/src/errors/BasicSpreeError.ts
@@ -6,7 +6,7 @@ class BasicSpreeError extends SpreeError {
 
   constructor(serverResponse: AxiosResponse, errorsSummary: string) {
     super(serverResponse)
-    Object.setPrototypeOf(this, new.target.prototype)
+    Object.setPrototypeOf(this, BasicSpreeError.prototype)
     this.name = 'BasicSpreeError'
     this.summary = errorsSummary
   }

--- a/src/errors/ExpandedSpreeError.ts
+++ b/src/errors/ExpandedSpreeError.ts
@@ -7,7 +7,7 @@ export default class ExpandedSpreeError extends BasicSpreeError {
 
   constructor(serverResponse: AxiosResponse, errorsSummary: string, errors: any) {
     super(serverResponse, errorsSummary)
-    Object.setPrototypeOf(this, new.target.prototype)
+    Object.setPrototypeOf(this, ExpandedSpreeError.prototype)
     this.name = 'ExpandedSpreeError'
     this.errors = Object.keys(errors).reduce((acc, field) => {
       const keys = field.split('.')

--- a/src/errors/MisconfigurationError.ts
+++ b/src/errors/MisconfigurationError.ts
@@ -3,7 +3,7 @@ import SpreeSDKError from './SpreeSDKError'
 export default class MisconfigurationError extends SpreeSDKError {
   constructor(message: string) {
     super(`Incorrect request setup: ${message}`)
-    Object.setPrototypeOf(this, new.target.prototype)
+    Object.setPrototypeOf(this, MisconfigurationError.prototype)
     this.name = 'MisconfigurationError'
   }
 }

--- a/src/errors/NoResponseError.ts
+++ b/src/errors/NoResponseError.ts
@@ -3,7 +3,7 @@ import SpreeSDKError from './SpreeSDKError'
 export default class NoResponseError extends SpreeSDKError {
   constructor() {
     super('No response received from Spree')
-    Object.setPrototypeOf(this, new.target.prototype)
+    Object.setPrototypeOf(this, NoResponseError.prototype)
     this.name = 'NoResponseError'
   }
 }

--- a/src/errors/SpreeError.ts
+++ b/src/errors/SpreeError.ts
@@ -6,7 +6,7 @@ export default class SpreeError extends SpreeSDKError {
 
   constructor(serverResponse: AxiosResponse) {
     super(`Spree returned a HTTP ${serverResponse.status} error code`)
-    Object.setPrototypeOf(this, new.target.prototype)
+    Object.setPrototypeOf(this, SpreeError.prototype)
     this.name = 'SpreeError'
     const reducedServerResponse = { ...serverResponse }
     // Reduce logging by removing the 'enumerable' flag on some keys in AxiosResponse.

--- a/src/errors/SpreeSDKError.ts
+++ b/src/errors/SpreeSDKError.ts
@@ -1,1 +1,6 @@
-export default class SpreeSDKError extends Error {}
+export default class SpreeSDKError extends Error {
+  constructor(name: string) {
+    super(name)
+    Object.setPrototypeOf(this, SpreeSDKError.prototype)
+  }
+}

--- a/types/errors/SpreeSDKError.d.ts
+++ b/types/errors/SpreeSDKError.d.ts
@@ -1,2 +1,3 @@
 export default class SpreeSDKError extends Error {
+    constructor(name: string);
 }


### PR DESCRIPTION
Issue described in detail here: https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work.