### PR TITLE
Add special_instructions in checkout update params

### DIFF
--- a/src/interfaces/endpoints/CheckoutClass.ts
+++ b/src/interfaces/endpoints/CheckoutClass.ts
@@ -11,6 +11,7 @@ export interface AddStoreCredit extends IQuery {
 export interface NestedAttributes extends IQuery {
   order?: {
     email?: string
+    special_instructions? :string
     bill_address_attributes?: IAddress
     ship_address_attributes?: IAddress
     payments_attributes?: IPayment[]

--- a/types/interfaces/endpoints/CheckoutClass.d.ts
+++ b/types/interfaces/endpoints/CheckoutClass.d.ts
@@ -9,6 +9,7 @@ export interface AddStoreCredit extends IQuery {
 export interface NestedAttributes extends IQuery {
     order?: {
         email?: string;
+        special_instructions?: string;
         bill_address_attributes?: IAddress;
         ship_address_attributes?: IAddress;
         payments_attributes?: IPayment[];


### PR DESCRIPTION
Mentioned in #158 , the checkout endpoint accepts `special_instructions` in params, but this is not reflected in types.
I added relevant definition.