### PR TITLE
Rethrow existing FetchError when caught

### DIFF
--- a/src/fetchers/createFetchFetcher.ts
+++ b/src/fetchers/createFetchFetcher.ts
@@ -47,6 +47,10 @@ const createCustomizedFetchFetcher: CreateCustomizedFetchFetcher = (fetcherOptio
 
           return { data }
         } catch (error) {
+          if (error instanceof FetchError) {
+            throw error
+          }
+
           throw new FetchError(null, request, null, error.message)
         }
       } catch (error) {


### PR DESCRIPTION
Notes:

The current implementation of `src/fetchers/createFetchFetcher.ts`, due to the limitations of the `async...await` syntax, is difficult to read. We should switch to using `Promise` directly or reorganise this code some other way. Nesting `try...catch` to have full control over thrown errors is not ideal.