### PR TITLE
Reference error classes from the core bundle in fetchers

### DIFF
--- a/Dockerfile.test-runtime
+++ b/Dockerfile.test-runtime
@@ -4,8 +4,11 @@ WORKDIR /sdk
 
 COPY . /sdk
 
-RUN npm install
-RUN npm run build
+RUN npm install --ignore-scripts
+RUN npm run build-core
+RUN npm link
+RUN npm link @spree/storefront-api-v2-sdk
+RUN npm run build-fetchers
 RUN npm pack
 
 FROM alpine

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "types": "types/index.d.ts",
   "scripts": {
     "prepare": "npm run build",
-    "build": "webpack",
+    "build-core": "BUILD_TYPE=core webpack",
+    "build-fetchers": "BUILD_TYPE=fetchers webpack",
+    "build": "npm run build-core && npm run build-fetchers",
     "build:server": "webpack --config-name server",
     "build:client": "webpack --config-name client",
     "watch": "webpack --watch",

--- a/src/fetchers/createAxiosFetcher.ts
+++ b/src/fetchers/createAxiosFetcher.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'axios'
 import type { CreateFetcher } from '../interfaces/ClientConfig'
-import FetchError from '../errors/FetchError'
+import { errors } from '@spree/storefront-api-v2-sdk'
 import { objectToQuerystring } from '../helpers/request'
 
 const createAxiosFetcher: CreateFetcher = (fetcherOptions) => {
@@ -70,7 +70,7 @@ const createAxiosFetcher: CreateFetcher = (fetcherOptions) => {
           const { response } = error
 
           if (!response) {
-            throw new FetchError(null, error.request, null, error.message)
+            throw new errors.FetchError(null, error.request, null, error.message)
           }
 
           const reducedResponse = { ...response }
@@ -83,10 +83,10 @@ const createAxiosFetcher: CreateFetcher = (fetcherOptions) => {
             request: { enumerable: false }
           })
 
-          throw new FetchError(reducedResponse, error.request, reducedResponse.data, error.message)
+          throw new errors.FetchError(reducedResponse, error.request, reducedResponse.data, error.message)
         }
 
-        throw new FetchError(null, null, null, error.message)
+        throw new errors.FetchError(null, null, null, error.message)
       }
     }
   }

--- a/src/fetchers/createFetchFetcher.ts
+++ b/src/fetchers/createFetchFetcher.ts
@@ -1,4 +1,4 @@
-import FetchError from '../errors/FetchError'
+import { errors } from '@spree/storefront-api-v2-sdk'
 import { objectToQuerystring } from '../helpers/request'
 import type { CreateFetcher } from '../interfaces/ClientConfig'
 import type { CreateCustomizedFetchFetcher } from '../interfaces/CreateCustomizedFetchFetcher'
@@ -58,23 +58,23 @@ const createCustomizedFetchFetcher: CreateCustomizedFetchFetcher = (fetcherOptio
 
           if (!response.ok) {
             // Use the "traditional" approach and reject non 2xx responses.
-            throw new FetchError(response, request, data)
+            throw new errors.FetchError(response, request, data)
           }
 
           return { data }
         } catch (error) {
-          if (error instanceof FetchError) {
+          if (error instanceof errors.FetchError) {
             throw error
           }
 
-          throw new FetchError(null, request, null, error.message)
+          throw new errors.FetchError(null, request, null, error.message)
         }
       } catch (error) {
-        if (error instanceof FetchError) {
+        if (error instanceof errors.FetchError) {
           throw error
         }
 
-        throw new FetchError(null, null, null, error.message)
+        throw new errors.FetchError(null, null, null, error.message)
       }
     }
   }

--- a/webpack.client.mjs
+++ b/webpack.client.mjs
@@ -17,6 +17,9 @@ const config = {
   output: {
     path: clientDistDirectoryPath
   },
+  externals: {
+    '@spree/storefront-api-v2-sdk': 'SpreeSDK'
+  },
   plugins: [
     new webpack.DefinePlugin({
       RUNTIME_TYPE: "'browser'"

--- a/webpack.common.maker.mjs
+++ b/webpack.common.maker.mjs
@@ -10,6 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const baseDirectoryPath = __dirname
 const srcDirectoryPath = resolve(baseDirectoryPath, 'src')
 const { WatchIgnorePlugin } = webpack
+const buildType = process.env.BUILD_TYPE
 
 export default ({ typeScriptConfigFilePath }) => ({
   context: baseDirectoryPath,
@@ -19,27 +20,35 @@ export default ({ typeScriptConfigFilePath }) => ({
     new WatchIgnorePlugin({ paths: [resolve(baseDirectoryPath, 'types')] })
   ],
   entry: {
-    index: {
-      import: resolve(srcDirectoryPath, 'index.ts'),
-      library: {
-        name: 'SpreeSDK',
-        type: 'umd'
-      }
-    },
-    createFetchFetcher: {
-      import: resolve(srcDirectoryPath, 'fetchers/createFetchFetcher.ts'),
-      library: {
-        name: ['SpreeSDK', 'createFetchFetcher'],
-        type: 'umd'
-      }
-    },
-    createAxiosFetcher: {
-      import: resolve(srcDirectoryPath, 'fetchers/createAxiosFetcher.ts'),
-      library: {
-        name: ['SpreeSDK', 'createAxiosFetcher'],
-        type: 'umd'
-      }
-    }
+    ...(buildType !== 'core'
+      ? null
+      : {
+          index: {
+            import: resolve(srcDirectoryPath, 'index.ts'),
+            library: {
+              name: 'SpreeSDK',
+              type: 'umd'
+            }
+          }
+        }),
+    ...(buildType !== 'fetchers'
+      ? null
+      : {
+          createFetchFetcher: {
+            import: resolve(srcDirectoryPath, 'fetchers/createFetchFetcher.ts'),
+            library: {
+              name: ['SpreeSDK', 'createFetchFetcher'],
+              type: 'umd'
+            }
+          },
+          createAxiosFetcher: {
+            import: resolve(srcDirectoryPath, 'fetchers/createAxiosFetcher.ts'),
+            library: {
+              name: ['SpreeSDK', 'createAxiosFetcher'],
+              type: 'umd'
+            }
+          }
+        })
   },
   output: {
     filename: '[name].js'
@@ -73,5 +82,5 @@ export default ({ typeScriptConfigFilePath }) => ({
     symlinks: false,
     extensions: ['.tsx', '.ts', '.js']
   },
-  externals: [nodeExternals({ modulesFromFile: true })]
+  externals: [nodeExternals()]
 })


### PR DESCRIPTION
For `instanceof` to properly recognize errors in the `HTTP` class,
fetchers need to reference errors from `@spree/storefront-api-v2-sdk`
and not from sources which duplicates error classes.