### PR TITLE
Add extension to sdk

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -45,7 +45,7 @@ class Client {
       ...customOptions
     }
 
-    const fetcherOptions: CreateFetcherConfig = { host: options.host }
+    const fetcherOptions: CreateFetcherConfig = { host: options.host, beforeRequestFunction: options?.beforeRequestFunction }
 
     this.fetcher = options.createFetcher(fetcherOptions)
 

--- a/src/Http.ts
+++ b/src/Http.ts
@@ -69,13 +69,14 @@ export default class Http {
   }
 
   protected processError(error: Error): SpreeSDKError {
-    if (error instanceof FetchError) {
-      if (error.response) {
+    if ((error as FetchError)?.response) {
+      const fetchError = (error as FetchError)
+      if (fetchError.response) {
         // Error from Spree outside HTTP 2xx codes
         return this.processSpreeError(error)
       }
 
-      if (error.request) {
+      if (fetchError.request) {
         // No response received from Spree
         return new NoResponseError()
       }

--- a/src/fetchers/createAxiosFetcher.ts
+++ b/src/fetchers/createAxiosFetcher.ts
@@ -18,6 +18,9 @@ const createAxiosFetcher: CreateFetcher = (fetcherOptions) => {
     headers: { 'Content-Type': 'application/json' },
     paramsSerializer: (params) => objectToQuerystring(params)
   })
+  if (fetcherOptions.beforeRequestFunction){
+    fetcherOptions?.beforeRequestFunction(axios)
+  }
 
   return {
     fetch: async (fetchOptions) => {

--- a/src/interfaces/ClientConfig.ts
+++ b/src/interfaces/ClientConfig.ts
@@ -1,4 +1,5 @@
 import type { FetchConfig } from './FetchConfig'
+import { AxiosInstance } from 'axios';
 
 export type Fetcher = {
   fetch: (options: FetchConfig) => Promise<{ data: any }>
@@ -8,10 +9,12 @@ export type CreateFetcher = (options: CreateFetcherConfig) => Fetcher
 
 export type CreateFetcherConfig = {
   host: string
+  beforeRequestFunction?(axios: AxiosInstance): any
 }
 
 export type FetcherConfig = {
   createFetcher: CreateFetcher
 }
+
 
 export type IClientConfig = CreateFetcherConfig & FetcherConfig


### PR DESCRIPTION
Fixed the bug where error 404 was not parsed as spree error, extended sdk to have custom function that can be specified by user