### PR TITLE
Fix error parsing

### DIFF
--- a/src/Http.ts
+++ b/src/Http.ts
@@ -69,13 +69,14 @@ export default class Http {
   }
 
   protected processError(error: Error): SpreeSDKError {
-    if (error instanceof FetchError) {
-      if (error.response) {
+    if ((error as FetchError)?.response) {
+      const fetchError = (error as FetchError)
+      if (fetchError.response) {
         // Error from Spree outside HTTP 2xx codes
         return this.processSpreeError(error)
       }
 
-      if (error.request) {
+      if (fetchError.request) {
         // No response received from Spree
         return new NoResponseError()
       }


### PR DESCRIPTION
PR with changes that will fix error parsing - separated from #341. now spree errors are actually parsed as fetch errors and the error is being thrown properly