### PR TITLE
Add braintree nonce to IPayment to support spree_braintree_vzero

### DIFF
--- a/src/interfaces/attributes/Payment.ts
+++ b/src/interfaces/attributes/Payment.ts
@@ -1,3 +1,4 @@
 export interface IPayment {
   payment_method_id: string
+  braintree_nonce?: string
 }


### PR DESCRIPTION
See #345 . The braintree nonce attribute is required to support `spree_braintree_vzero`.