### PR TITLE
Add documentation using typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log
 /types
 *.tgz
 
+/docs
 /packages/sdk-core/dist
 /packages/sdk-core/types
 /packages/sdk-fetcher-axios/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@spree/storefront-api-sdk",
+  "name": "spree-storefront-api-sdk",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@spree/storefront-api-sdk",
+      "name": "spree-storefront-api-sdk",
       "license": "MIT",
       "workspaces": [
         "packages/sdk-core",
@@ -13,6 +13,10 @@
       ],
       "dependencies": {
         "npm": "^8.19.2"
+      },
+      "devDependencies": {
+        "@knodes/typedoc-plugin-pages": "^0.23.1",
+        "typedoc": "^0.23.16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -232,6 +236,34 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@knodes/typedoc-plugin-pages": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@knodes/typedoc-plugin-pages/-/typedoc-plugin-pages-0.23.1.tgz",
+      "integrity": "sha512-Zhe4ZTDbnxBNZir/aB4dP7WMaF4k8Idx/DlwJAizvhL6cv0a7W+ulpG2eTweU7R4B3uaiKoR9+c0Yulfq0W/9g==",
+      "dev": true,
+      "dependencies": {
+        "@knodes/typedoc-pluginutils": "~0.23.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "lunr": "^2.3.0",
+        "typedoc": "^0.23.0"
+      }
+    },
+    "node_modules/@knodes/typedoc-pluginutils": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@knodes/typedoc-pluginutils/-/typedoc-pluginutils-0.23.1.tgz",
+      "integrity": "sha512-WjGG7bSFpZ0um6R1Lr5bnQuDROgwHOCcbjeXpAHjFjrTpTXsQgmzkcK36ybhMLh9VBqjt5m1MK41pClpUzqYEA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "peerDependencies": {
+        "typedoc": "^0.23.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2500,6 +2532,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -2557,6 +2595,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2579,6 +2623,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.1.tgz",
+      "integrity": "sha512-VK1/jNtwqDLvPktNpL0Fdg3qoeUZhmRsuiIjPEy/lHwXW4ouLoZfO4XoWd4ClDt+hupV1VLpkZhEovjU0W/kqA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/memory-fs": {
@@ -5277,6 +5339,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5645,6 +5765,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
       }
     },
     "node_modules/side-channel": {
@@ -6073,10 +6204,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.16.tgz",
+      "integrity": "sha512-rumYsCeNRXlyuZVzefD7050n7ptL2uudsCJg50dY0v/stKniqIlRpvx/F/6expC0/Q6Dbab+g/JpZuB7Sw90FA==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6146,6 +6319,18 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "node_modules/watchpack": {
@@ -6645,6 +6830,27 @@
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "@knodes/typedoc-plugin-pages": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@knodes/typedoc-plugin-pages/-/typedoc-plugin-pages-0.23.1.tgz",
+      "integrity": "sha512-Zhe4ZTDbnxBNZir/aB4dP7WMaF4k8Idx/DlwJAizvhL6cv0a7W+ulpG2eTweU7R4B3uaiKoR9+c0Yulfq0W/9g==",
+      "dev": true,
+      "requires": {
+        "@knodes/typedoc-pluginutils": "~0.23.1",
+        "lodash": "^4.17.21"
+      }
+    },
+    "@knodes/typedoc-pluginutils": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@knodes/typedoc-pluginutils/-/typedoc-pluginutils-0.23.1.tgz",
+      "integrity": "sha512-WjGG7bSFpZ0um6R1Lr5bnQuDROgwHOCcbjeXpAHjFjrTpTXsQgmzkcK36ybhMLh9VBqjt5m1MK41pClpUzqYEA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
       }
     },
     "@nodelib/fs.scandir": {
@@ -8342,6 +8548,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -8384,6 +8596,12 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -8404,6 +8622,18 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.1.tgz",
+      "integrity": "sha512-VK1/jNtwqDLvPktNpL0Fdg3qoeUZhmRsuiIjPEy/lHwXW4ouLoZfO4XoWd4ClDt+hupV1VLpkZhEovjU0W/kqA==",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.5.0",
@@ -10228,6 +10458,51 @@
         "find-up": "^4.0.0"
       }
     },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10481,6 +10756,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -10785,10 +11071,42 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.23.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.16.tgz",
+      "integrity": "sha512-rumYsCeNRXlyuZVzefD7050n7ptL2uudsCJg50dY0v/stKniqIlRpvx/F/6expC0/Q6Dbab+g/JpZuB7Sw90FA==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.19",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {
@@ -10832,6 +11150,18 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spree/storefront-api-sdk",
+  "name": "spree-storefront-api-sdk",
   "private": true,
   "description": "Node module to easily integrate your JavaScript or TypeScript application with Spree API V2. You can create an entirely custom Storefront in JS/TS with this package including one page checkout, Single Page Apps, PWAs and so on",
   "scripts": {
@@ -12,7 +12,8 @@
     "pack:sdk-fetcher-fetch": "npm pack --workspace=@spree/storefront-api-v2-sdk-node-fetch --pack-destination=packages/sdk-fetcher-node-fetch",
     "pack": "npm run pack:sdk && npm run pack:sdk-fetcher-axios && npm run pack:sdk-fetcher-fetch",
     "lint": "eslint --ext .ts .",
-    "test": "./test.sh"
+    "test": "./test.sh",
+    "docs": "typedoc"
   },
   "repository": {
     "type": "git",
@@ -32,5 +33,9 @@
   ],
   "dependencies": {
     "npm": "^8.19.2"
+  },
+  "devDependencies": {
+    "typedoc": "^0.23.16",
+    "@knodes/typedoc-plugin-pages": "^0.23.1"
   }
 }

--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -1,0 +1,1 @@
+Spree Storefront API SDK contains each endpoint according to [Spree Guides](https://api.spreecommerce.org/docs/api-v2/c230c08afa8e4-storefront-api).

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -61,5 +61,8 @@
     "axios": {
       "optional": true
     }
+  },
+  "typedoc": {
+    "entryPoint": "./src/endpoints/index.ts"
   }
 }

--- a/packages/sdk-core/src/endpoints/Account.ts
+++ b/packages/sdk-core/src/endpoints/Account.ts
@@ -37,87 +37,29 @@ import type { IToken } from '../interfaces/Token'
 import routes from '../routes'
 
 export default class Account extends Http {
-  public async accountInfo(options: AccountInfoOptions): Promise<IAccountResult>
   /**
-   * @deprecated Use the combined options signature instead.
+   * Creates new account and returns its attributes. See [api docs](https://api.spreecommerce.org/docs/api-v2/534a12ece987f-create-an-account).
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.create({
+   *   user: {
+   *     email: 'john@snow.org',
+   *     password: 'spree123',
+   *     password_confirmation: 'spree123'
+   *   }
+   * })
+   * ```
    */
-  public async accountInfo(token: IToken, params?: IQuery): Promise<IAccountResult>
-  public async accountInfo(...allArguments: any[]): Promise<IAccountResult> {
-    const [tokenOrOptions, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<IAccount>('get', routes.accountPath(), token, params)
-  }
-
-  public async creditCardsList(options: CreditCardsListOptions): Promise<ICreditCardsResult>
-  /**
-   * @deprecated Use the combined options signature instead.
-   */
-  public async creditCardsList(token: IToken, params?: IQuery): Promise<ICreditCardsResult>
-  public async creditCardsList(...allArguments: any[]): Promise<ICreditCardsResult> {
-    const [tokenOrOptions, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<ICreditCards>('get', routes.accountCreditCardsPath(), token, params)
-  }
-
-  public async defaultCreditCard(options: DefaultCreditCardOptions): Promise<ICreditCardResult>
-  /**
-   * @deprecated Use the combined options signature instead.
-   */
-  public async defaultCreditCard(token: IToken, params?: IQuery): Promise<ICreditCardResult>
-  public async defaultCreditCard(...allArguments: any[]): Promise<ICreditCardResult> {
-    const [tokenOrOptions, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<ICreditCard>('get', routes.accountDefaultCreditCardPath(), token, params)
-  }
-
-  public async removeCreditCard(options: RemoveCreditCardOptions): Promise<NoContentResult>
-  /**
-   * @deprecated Use the combined options signature instead.
-   */
-  public async removeCreditCard(token: IToken, id: string, params?: IQuery): Promise<NoContentResult>
-  public async removeCreditCard(...allArguments: any[]): Promise<NoContentResult> {
-    const [tokenOrOptions, positionalId, positionalParams = {}] = allArguments
-    const { id, token, params } = squashAndPreparePositionalArguments(
-      [{ id: positionalId }, tokenOrOptions, positionalParams],
-      ['id']
-    )
-
-    return await this.spreeResponse<NoContentResponse>('delete', routes.accountCreditCardRemovePath(id), token, params)
-  }
-
-  public async completedOrdersList(options: CompletedOrdersListOptions): Promise<IOrdersResult>
-  /**
-   * @deprecated Use the combined options signature instead.
-   */
-  public async completedOrdersList(token: IToken, params?: IQuery): Promise<IOrdersResult>
-  public async completedOrdersList(...allArguments: any[]): Promise<IOrdersResult> {
-    const [tokenOrOptions, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<IOrders>('get', routes.accountCompletedOrdersPath(), token, params)
-  }
-
-  public async completedOrder(options: CompletedOrderOptions): Promise<IOrderResult>
-  /**
-   * @deprecated Use the combined options signature instead.
-   */
-  public async completedOrder(token: IToken, orderNumber: string, params?: IQuery): Promise<IOrderResult>
-  public async completedOrder(...allArguments: any[]): Promise<IOrderResult> {
-    const [tokenOrOptions, positionalOrderNumber, positionalParams = {}] = allArguments
-    const { order_number, token, params } = squashAndPreparePositionalArguments(
-      [{ order_number: positionalOrderNumber }, tokenOrOptions, positionalParams],
-      ['order_number']
-    )
-
-    return await this.spreeResponse<IOrder>('get', routes.accountCompletedOrderPath(order_number), token, params)
-  }
-
   public async create(options: CreateOptions): Promise<IAccountResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
+   * Creates new account and returns its attributes.
    */
   public async create(params: IQuery): Promise<IAccountResult>
   public async create(...allArguments: any[]): Promise<IAccountResult> {
@@ -127,8 +69,27 @@ export default class Account extends Http {
     return await this.spreeResponse<IAccount>('post', routes.accountPath(), token, params)
   }
 
+  /**
+   * Confirms new account e-mail and returns account registration status. See [reference](https://github.com/spree/spree_auth_devise/blob/db4ccf202f42cdb713931e9915b213ab9c9b2062/config/routes.rb).
+   * 
+   * **Success response schema:**
+   * ```ts
+   * {
+   *   data: {
+   *     state: string
+   *   }
+   * }
+   * ```
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.confirm({ confirmation_token: '2xssfC9Hzf8DJXyRZGmB' })
+   * ```
+   */
   public async confirm(option: ConfirmOptions): Promise<IAccountConfirmationResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async confirm(confirmationToken: string): Promise<IAccountConfirmationResult>
@@ -151,8 +112,25 @@ export default class Account extends Http {
     )
   }
 
+  /**
+   * Sends an account recovery link to the provided email address. The link allows resetting the password for the account.
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.forgotPassword({
+   *   user: {
+   *     email: 'spree@example.com'
+   *   }
+   * })
+   * ```
+   */
   public async forgotPassword(options: ForgotPasswordOptions): Promise<NoContentResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async forgotPassword(params: ForgotPasswordParams): Promise<NoContentResult>
@@ -163,8 +141,27 @@ export default class Account extends Http {
     return await this.spreeResponse<NoContentResponse>('post', routes.forgotPasswordPath(), token, params)
   }
 
+  /**
+   * Changes the password associated with the account using an account recovery token.
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.resetPassword({
+   *   reset_password_token: '7381273269536713689562374856',
+   *   user: {
+   *     password: '123!@#asdASD',
+   *     password_confirmation: '123!@#asdASD'
+   *   }
+   * })
+   * ```
+   */
   public async resetPassword(options: ResetPasswordOptions): Promise<NoContentResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async resetPassword(resetPasswordToken: string, params: ResetPasswordParams): Promise<NoContentResult>
@@ -188,8 +185,30 @@ export default class Account extends Http {
     )
   }
 
+  /**
+   * Updates account and returns its attributes. See [api docs](https://api.spreecommerce.org/docs/api-v2/9f8e112bbb91f-update-an-account).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.update({
+   *   bearer_token: '7381273269536713689562374856',
+   *   user: {
+   *     email: 'john@snow.org',
+   *     password: 'new_spree123',
+   *     password_confirmation: 'new_spree123'
+   *   }
+   * })
+   * ```
+   */
   public async update(options: UpdateOptions): Promise<IAccountResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async update(token: IToken, params: IQuery): Promise<IAccountResult>
@@ -200,8 +219,201 @@ export default class Account extends Http {
     return await this.spreeResponse<IAccount>('patch', routes.accountPath(), token, params)
   }
 
+  /**
+   * Returns current user information. See [api docs](https://api.spreecommerce.org/docs/api-v2/a531029531471-retrieve-an-account).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.accountInfo({ bearer_token: '7381273269536713689562374856' })
+   * ```
+   */
+  public async accountInfo(options: AccountInfoOptions): Promise<IAccountResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async accountInfo(token: IToken, params?: IQuery): Promise<IAccountResult>
+  public async accountInfo(...allArguments: any[]): Promise<IAccountResult> {
+    const [tokenOrOptions, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+
+    return await this.spreeResponse<IAccount>('get', routes.accountPath(), token, params)
+  }
+
+  /**
+   * Returns a list of Credit Cards for the signed in User. See [api docs](https://api.spreecommerce.org/docs/api-v2/eae76f03a90db-list-all-credit-cards).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.creditCardsList({ bearer_token: '7381273269536713689562374856' })
+   * ```
+   */
+  public async creditCardsList(options: CreditCardsListOptions): Promise<ICreditCardsResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async creditCardsList(token: IToken, params?: IQuery): Promise<ICreditCardsResult>
+  public async creditCardsList(...allArguments: any[]): Promise<ICreditCardsResult> {
+    const [tokenOrOptions, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+
+    return await this.spreeResponse<ICreditCards>('get', routes.accountCreditCardsPath(), token, params)
+  }
+
+  /**
+   * Return the User's default Credit Card. See [api docs](https://api.spreecommerce.org/docs/api-v2/1054d9230daf4-retrieve-the-default-credit-card).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.defaultCreditCard({ bearer_token: '7381273269536713689562374856' })
+   * ```
+   */
+  public async defaultCreditCard(options: DefaultCreditCardOptions): Promise<ICreditCardResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async defaultCreditCard(token: IToken, params?: IQuery): Promise<ICreditCardResult>
+  public async defaultCreditCard(...allArguments: any[]): Promise<ICreditCardResult> {
+    const [tokenOrOptions, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+
+    return await this.spreeResponse<ICreditCard>('get', routes.accountDefaultCreditCardPath(), token, params)
+  }
+
+  /**
+   * Remove a User's Credit Card. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MTc1NjU3NDM-remove-a-credit-card).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.removeCreditCard({
+   *   bearer_token: '7381273269536713689562374856',
+   *   id: '14'
+   * })
+   * ```
+   */
+  public async removeCreditCard(options: RemoveCreditCardOptions): Promise<NoContentResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async removeCreditCard(token: IToken, id: string, params?: IQuery): Promise<NoContentResult>
+  public async removeCreditCard(...allArguments: any[]): Promise<NoContentResult> {
+    const [tokenOrOptions, positionalId, positionalParams = {}] = allArguments
+    const { id, token, params } = squashAndPreparePositionalArguments(
+      [{ id: positionalId }, tokenOrOptions, positionalParams],
+      ['id']
+    )
+
+    return await this.spreeResponse<NoContentResponse>('delete', routes.accountCreditCardRemovePath(id), token, params)
+  }
+
+  /**
+   * Returns Orders placed by the User. Only completed ones. See [api docs](https://api.spreecommerce.org/docs/api-v2/94d319dfe8909-list-all-orders).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.completedOrdersList({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
+  public async completedOrdersList(options: CompletedOrdersListOptions): Promise<IOrdersResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async completedOrdersList(token: IToken, params?: IQuery): Promise<IOrdersResult>
+  public async completedOrdersList(...allArguments: any[]): Promise<IOrdersResult> {
+    const [tokenOrOptions, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+
+    return await this.spreeResponse<IOrders>('get', routes.accountCompletedOrdersPath(), token, params)
+  }
+
+  /**
+   * Return the User's completed Order. See [api docs](https://api.spreecommerce.org/docs/api-v2/ab4c5da10fbba-retrieve-an-order).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.completedOrder({
+   *   bearer_token: '7381273269536713689562374856',
+   *   order_number: 'R653163382'
+   * })
+   * ```
+   */
+  public async completedOrder(options: CompletedOrderOptions): Promise<IOrderResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async completedOrder(token: IToken, orderNumber: string, params?: IQuery): Promise<IOrderResult>
+  public async completedOrder(...allArguments: any[]): Promise<IOrderResult> {
+    const [tokenOrOptions, positionalOrderNumber, positionalParams = {}] = allArguments
+    const { order_number, token, params } = squashAndPreparePositionalArguments(
+      [{ order_number: positionalOrderNumber }, tokenOrOptions, positionalParams],
+      ['order_number']
+    )
+
+    return await this.spreeResponse<IOrder>('get', routes.accountCompletedOrderPath(order_number), token, params)
+  }
+
+  /**
+   * Returns a list of Addresses for the signed in User. See [api docs](https://api.spreecommerce.org/docs/api-v2/c8ebb212f75bf-list-all-addresses).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.addressesList({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async addressesList(options: AddressesListOptions): Promise<AccountAddressesResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async addressesList(token: IToken): Promise<AccountAddressesResult>
@@ -212,8 +424,26 @@ export default class Account extends Http {
     return await this.spreeResponse<AccountAddressesResponse>('get', routes.accountAddressesPath(), token, params)
   }
 
+  /**
+   * Returns a single address for the signed in User.
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.showAddress({
+   *   bearer_token: '7381273269536713689562374856',
+   *   id: '1'
+   * })
+   * ```
+   */
   public async showAddress(options: ShowAddressOptions): Promise<AccountAddressResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async showAddress(token: IToken, addressId: string, params?: IQuery): Promise<AccountAddressResult>
@@ -227,8 +457,55 @@ export default class Account extends Http {
     return await this.spreeResponse<AccountAddressResponse>('get', routes.accountAddressPath(id), token, params)
   }
 
+  /**
+   * Create a new Address for the signed in User. See [api docs](https://api.spreecommerce.org/docs/api-v2/daacab4666dfc-create-an-address).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   address: {
+   *     firstname: string
+   *     lastname: string
+   *     address1: string
+   *     address2?: string
+   *     city: string
+   *     phone?: string
+   *     zipcode: string
+   *     state_name: string // State Abbreviations
+   *     country_iso: string // Country ISO (2-chars) or ISO3 (3-chars)
+   *     company?: string
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.createAddress({
+   *   bearer_token: '7381273269536713689562374856',
+   *   address: {
+   *     firstname: 'John',
+   *     lastname: 'Snow',
+   *     address1: '7735 Old Georgetown Road',
+   *     address2: '2nd Floor',
+   *     city: 'Bethesda',
+   *     phone: '3014445002',
+   *     zipcode: '20814',
+   *     state_name: 'MD',
+   *     country_iso: 'US',
+   *     company: 'Spark'
+   *   }
+   * })
+   * ```
+   */
   public async createAddress(options: CreateAddressOptions): Promise<AccountAddressResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async createAddress(token: IToken, params: AccountAddressParams): Promise<AccountAddressResult>
@@ -239,8 +516,26 @@ export default class Account extends Http {
     return await this.spreeResponse<AccountAddressResponse>('post', routes.accountAddressesPath(), token, params)
   }
 
+  /**
+   * Removes selected Address for the signed in User. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MTAwNjA3Njg-remove-an-address).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.removeAddress({
+   *   bearer_token: '7381273269536713689562374856',
+   *   id: '1'
+   * })
+   * ```
+   */
   public async removeAddress(options: RemoveAddressOptions): Promise<NoContentResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeAddress(token: IToken, id: string, params?: IQuery): Promise<NoContentResult>
@@ -254,8 +549,57 @@ export default class Account extends Http {
     return await this.spreeResponse<NoContentResponse>('delete', routes.accountAddressRemovePath(id), token, params)
   }
 
+  /**
+   * Update selected Address for the signed in User. See [api docs](https://api.spreecommerce.org/docs/api-v2/fbae19a10190d-update-an-address).
+   * 
+   * Required token: Bearer token
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   *   address: {
+   *     firstname: string
+   *     lastname: string
+   *     address1: string
+   *     address2?: string
+   *     city: string
+   *     phone?: string
+   *     zipcode: string
+   *     state_name: string // State Abbreviations
+   *     country_iso: string // Country ISO (2-chars) or ISO3 (3-chars)
+   *     company?: string
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.account.updateAddress({
+   *   bearer_token: '7381273269536713689562374856',
+   *   id: '1',
+   *   address: {
+   *     firstname: 'John',
+   *     lastname: 'Snow',
+   *     address1: '7735 Old Georgetown Road',
+   *     address2: '2nd Floor',
+   *     city: 'Bethesda',
+   *     phone: '3014445002',
+   *     zipcode: '20814',
+   *     state_name: 'MD',
+   *     country_iso: 'US',
+   *     company: 'Spark'
+   *   }
+   * })
+   * ```
+   */
   public async updateAddress(options: UpdateAddressOptions): Promise<AccountAddressResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async updateAddress(

--- a/packages/sdk-core/src/endpoints/Authentication.ts
+++ b/packages/sdk-core/src/endpoints/Authentication.ts
@@ -14,8 +14,33 @@ import routes from '../routes'
 import squashAndPreparePositionalArguments from '../helpers/squashAndPreparePositionalArguments'
 
 export default class Authentication extends Http {
+  /**
+   * Creates a [Bearer token](../pages/tokens.html#bearer-token) required to authorize OAuth API calls.
+   * 
+   * **Success response schema:**
+   * ```ts
+   * interface res {
+   *   access_token: string
+   *   token_type: string = 'Bearer'
+   *   expires_in: number
+   *   refresh_token: string
+   *   created_at: number
+   * }
+   * ```
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const token = await client.authentication.getToken({
+   *   username: 'spree@example.com',
+   *   password: 'spree123'
+   * })
+   * ```
+   */
   public async getToken(options: GetTokenOptions): Promise<IOAuthTokenResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async getToken(params: AuthTokenAttr): Promise<IOAuthTokenResult>
@@ -31,8 +56,32 @@ export default class Authentication extends Http {
     )
   }
 
+  /**
+   * Refreshes the [Bearer token](../pages/tokens.html#bearer-token) required to authorize OAuth API calls.
+   * 
+   * **Success response schema:**
+   * ```ts
+   * interface res {
+   *   access_token: string
+   *   token_type: string = 'Bearer'
+   *   expires_in: number
+   *   refresh_token: string
+   *   created_at: number
+   * }
+   * ```
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const token = await client.authentication.refreshToken({
+   *   refresh_token: 'aebe2886d7dbba6f769e20043e40cfa3447e23ad9d8e82c632f60ed63a2f0df1'
+   * })
+   * ```
+   */
   public async refreshToken(options: RefreshTokenOptions): Promise<IOAuthTokenResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async refreshToken(params: RefreshTokenAttr): Promise<IOAuthTokenResult>
@@ -48,8 +97,23 @@ export default class Authentication extends Http {
     )
   }
 
+  /**
+   * Revokes a [Bearer token (access token)](../pages/tokens.html#bearer-token) or a refresh token.
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.authentication.revokeToken({
+   *   token: 'aebe2886d7dbba6f769e20043e40cfa3447e23ad9d8e82c632f60ed63a2f0df1'
+   * })
+   * ```
+   */
   public async revokeToken(optons: RevokeTokenOptions): Promise<EmptyObjectResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async revokeToken(params: RevokeTokenAttr): Promise<EmptyObjectResult>

--- a/packages/sdk-core/src/endpoints/Cart.ts
+++ b/packages/sdk-core/src/endpoints/Cart.ts
@@ -37,8 +37,64 @@ import type {
 } from '../interfaces/Cart'
 
 export default class Cart extends Http {
+  /**
+   * Creates a new Cart and returns its attributes. See [api docs](https://api.spreecommerce.org/docs/api-v2/6a57a5a49594f-create-a-cart).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) - if logged in user
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.create({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   * 
+   * // or guest user
+   * const response = await client.cart.create()
+   * ```
+   */
+  public async create(options?: CreateOptions): Promise<IOrderResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async create(token?: IToken, params?: IQuery): Promise<IOrderResult>
+  public async create(...allArguments: any[]): Promise<IOrderResult> {
+    const [tokenOrOptions = {}, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+ 
+    return await this.spreeResponse<IOrder>('post', routes.cartPath(), token, params)
+  }
+  
+  /**
+   * Returns contents of the cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc0Ng-retrieve-a-cart).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.show({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.show({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(token: IToken, params?: IQuery): Promise<IOrderResult>
@@ -49,20 +105,46 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('get', routes.cartPath(), token, params)
   }
 
-  public async create(options?: CreateOptions): Promise<IOrderResult>
   /**
-   * @deprecated Use the combined options signature instead.
+   * Adds a Product Variant to the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc0Nw-add-an-item-to-cart).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   variant_id: string
+   *   quantity: number
+   *   options?: {
+   *     [key: string]: string
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.addItem({
+   *   bearer_token: '7381273269536713689562374856',
+   *   variant_id: '1',
+   *   quantity: 1
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.addItem({
+   *   order_token: '7381273269536713689562374856',
+   *   variant_id: '1',
+   *   quantity: 1
+   * })
+   * ```
    */
-  public async create(token?: IToken, params?: IQuery): Promise<IOrderResult>
-  public async create(...allArguments: any[]): Promise<IOrderResult> {
-    const [tokenOrOptions = {}, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<IOrder>('post', routes.cartPath(), token, params)
-  }
-
   public async addItem(options: AddItemOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async addItem(token: IToken, params: AddItem): Promise<IOrderResult>
@@ -73,8 +155,87 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('post', routes.cartAddItemPath(), token, params)
   }
 
+  /**
+   * Sets the quantity of a given line item. It has to be a positive integer greater than 0. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc0OA-set-line-item-quantity).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   line_item_id: string
+   *   quantity: number
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.setQuantity({
+   *   bearer_token: '7381273269536713689562374856',
+   *   line_item_id: '9',
+   *   quantity: 100
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.setQuantity({
+   *   order_token: '7381273269536713689562374856',
+   *   line_item_id: '9',
+   *   quantity: 100
+   * })
+   * ```
+   */
+   public async setQuantity(options: SetQuantityOptions): Promise<IOrderResult>
+   /**
+    * @hidden
+    * @deprecated Use the combined options signature instead.
+    */
+   public async setQuantity(token: IToken, params: SetQuantity): Promise<IOrderResult>
+   public async setQuantity(...allArguments: any[]): Promise<IOrderResult> {
+     const [tokenOrOptions, positionalParams] = allArguments
+     const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+ 
+     return await this.spreeResponse<IOrder>('patch', routes.cartSetItemQuantity(), token, params)
+   }
+
+  /**
+   * Removes Line Item from Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/8b7783ed322f1-remove-a-line-item).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.removeItem({
+   *   bearer_token: '7381273269536713689562374856',
+   *   id: '1'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.removeItem({
+   *   order_token: '7381273269536713689562374856',
+   *   id: '1'
+   * })
+   * ```
+   */
   public async removeItem(options: RemoveItemOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeItem(token: IToken, id: string, params?: IQuery): Promise<IOrderResult>
@@ -88,8 +249,31 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('delete', routes.cartRemoveItemPath(id), token, params)
   }
 
+  /**
+   * Empties the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1MA-empty-the-cart).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.emptyCart({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.emptyCart({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async emptyCart(options: EmptyCartOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async emptyCart(token: IToken, params?: IQuery): Promise<IOrderResult>
@@ -100,8 +284,31 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.cartEmptyPath(), token, params)
   }
 
+  /**
+   * Removes the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MTcyNTA0NDc-delete-a-cart).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.remove({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.remove({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async remove(options: RemoveOptions): Promise<NoContentResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async remove(token: IToken): Promise<NoContentResult>
@@ -112,20 +319,39 @@ export default class Cart extends Http {
     return await this.spreeResponse<NoContentResponse>('delete', routes.cartPath(), token, params)
   }
 
-  public async setQuantity(options: SetQuantityOptions): Promise<IOrderResult>
   /**
-   * @deprecated Use the combined options signature instead.
+   * Applies a coupon code to the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1MQ-apply-a-coupon-code).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   coupon_code: string
+   * }
+   * ```
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.applyCouponCode({
+   *   bearer_token: '7381273269536713689562374856',
+   *   coupon_code: 'promo_test'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.applyCouponCode({
+   *   order_token: '7381273269536713689562374856',
+   *   coupon_code: 'promo_test'
+   * })  
+   * ```
    */
-  public async setQuantity(token: IToken, params: SetQuantity): Promise<IOrderResult>
-  public async setQuantity(...allArguments: any[]): Promise<IOrderResult> {
-    const [tokenOrOptions, positionalParams] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<IOrder>('patch', routes.cartSetItemQuantity(), token, params)
-  }
-
   public async applyCouponCode(options: ApplyCouponCodeOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async applyCouponCode(token: IToken, params: CouponCode): Promise<IOrderResult>
@@ -136,8 +362,40 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.cartApplyCodePath(), token, params)
   }
 
+  /**
+   * Removes a coupon code from the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1Mg-remove-a-coupon).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   code?: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.removeCouponCode({
+   *   bearer_token: '7381273269536713689562374856',
+   *   code: 'promo_test'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.removeCouponCode({
+   *   order_token: '7381273269536713689562374856',
+   *   code: 'promo_test'
+   * }) 
+   * ```
+   */
   public async removeCouponCode(options: RemoveCouponCodeOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeCouponCode(token: IToken, code: string, params?: IQuery): Promise<IOrderResult>
@@ -159,8 +417,31 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('delete', route, token, params)
   }
 
+  /**
+   * Removes all coupon codes from the Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjM5NTU3NTg-remove-all-coupons).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.removeAllCoupons({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.removeAllCoupons({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async removeAllCoupons(options: RemoveAllCouponsOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeAllCoupons(token: IToken, params: IQuery): Promise<IOrderResult>
@@ -172,6 +453,7 @@ export default class Cart extends Http {
   }
 
   /**
+   * @hidden
    * @deprecated Use {@link estimateShippingRates} instead.
    */
   public async estimateShippingMethods(
@@ -186,8 +468,40 @@ export default class Cart extends Http {
     )
   }
 
+  /**
+   * Returns a list of Estimated Shipping Rates for Cart. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1Mw-list-estimated-shipping-rates).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   country_iso: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.estimateShippingRates({
+   *   bearer_token: '7381273269536713689562374856',
+   *   country_iso: 'USA'
+   * })
+   *
+   * // or guest user
+   * const response = await client.cart.estimateShippingRates({
+   *   order_token: '7381273269536713689562374856',
+   *   country_iso: 'USA'
+   * })
+   * ```
+   */
   public async estimateShippingRates(options: EstimateShippingRatesOptions): Promise<EstimatedShippingRatesResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async estimateShippingRates(
@@ -206,8 +520,34 @@ export default class Cart extends Http {
     )
   }
 
+  /**
+   * Associates a guest cart with the currently signed in user. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjAxMTAyMzM-associate-a-cart-with-a-user).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   guest_order_token: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.associateGuestCart({
+   *   bearer_token: '7381273269536713689562374856',
+   *   guest_order_token: 'aebe2886d7dbba6f769e20043e40cfa3447e23ad9d8e82c632f60ed63a2f0df1'
+   * })
+   * ```
+   */
   public async associateGuestCart(options: AssociateGuestCartOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async associateGuestCart(token: IToken, params: AssociateCart): Promise<IOrderResult>
@@ -218,8 +558,34 @@ export default class Cart extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.cartAssociatePath(), token, params)
   }
 
+  /**
+   * Changes the Cart's currency. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjA2OTMwMDM-change-cart-currency).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   new_currency: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.cart.changeCurrency({
+   *   bearer_token: '7381273269536713689562374856',
+   *   new_currency: 'CAD'
+   * })
+   * ```
+   */
   public async changeCurrency(options: ChangeCurrencyOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async changeCurrency(token: IToken, params: ChangeCurrency): Promise<IOrderResult>

--- a/packages/sdk-core/src/endpoints/Checkout.ts
+++ b/packages/sdk-core/src/endpoints/Checkout.ts
@@ -35,20 +35,73 @@ import type { IToken } from '../interfaces/Token'
 import routes from '../routes'
 
 export default class Checkout extends Http {
-  public async orderNext(options: OrderNextOptions): Promise<IOrderResult>
   /**
-   * @deprecated Use the combined options signature instead.
+   * Updates the Checkout. You can run multiple Checkout updates with different data types. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1NA-update-checkout).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   order: {
+   *     email?: string
+   *     special_instructions?: string
+   *     bill_address_attributes?: {
+   *       firstname: string
+   *       lastname: string
+   *       address1: string
+   *       city: string
+   *       phone: string
+   *       zipcode: string
+   *       state_name: string
+   *       country_iso: string
+   *     }
+   *     ship_address_attributes?: {
+   *       firstname: string
+   *       lastname: string
+   *       address1: string
+   *       city: string
+   *       phone: string
+   *       zipcode: string
+   *       state_name: string
+   *       country_iso: string
+   *     }
+   *     shipments_attributes?: [
+   *       {
+   *         selected_shipping_rate_id: number
+   *         id: number
+   *       }
+   *     ]
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.orderUpdate({
+   *   bearer_token: '7381273269536713689562374856',
+   *   order: {
+   *     email: 'john@snow.org'
+   *   }
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.orderUpdate({
+   *   order_token: '7381273269536713689562374856',
+   *   order: {
+   *     email: 'john@snow.org'
+   *   }
+   * })
+   * ```
    */
-  public async orderNext(token: IToken, params?: IQuery): Promise<IOrderResult>
-  public async orderNext(...allArguments: any[]): Promise<IOrderResult> {
-    const [tokenOrOptions, positionalParams = {}] = allArguments
-    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
-
-    return await this.spreeResponse<IOrder>('patch', routes.checkoutNextPath(), token, params)
-  }
-
   public async orderUpdate(options: OrderUpdateOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async orderUpdate(token: IToken, params: OrderUpdate | NestedAttributes): Promise<IOrderResult>
@@ -59,8 +112,66 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.checkoutPath(), token, params)
   }
 
+  /**
+   * Goes to the next Checkout step. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1NQ-next-checkout-step).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.orderNext({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.orderNext({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
+  public async orderNext(options: OrderNextOptions): Promise<IOrderResult>
+  /**
+   * @hidden
+   * @deprecated Use the combined options signature instead.
+   */
+  public async orderNext(token: IToken, params?: IQuery): Promise<IOrderResult>
+  public async orderNext(...allArguments: any[]): Promise<IOrderResult> {
+    const [tokenOrOptions, positionalParams = {}] = allArguments
+    const { token, params } = squashAndPreparePositionalArguments([tokenOrOptions, positionalParams], [])
+
+    return await this.spreeResponse<IOrder>('patch', routes.checkoutNextPath(), token, params)
+  }
+
+  /**
+   * Advances Checkout to the furthest Checkout step validation allows, until the Complete step. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1Ng-advance-checkout).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.advance({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.advance({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async advance(options: AdvanceOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async advance(token: IToken, params?: IQuery): Promise<IOrderResult>
@@ -71,8 +182,31 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.checkoutAdvancePath(), token, params)
   }
 
+  /**
+   * Completes the Checkout. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1Nw-complete-checkout).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.complete({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.complete({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async complete(options: CompleteOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async complete(token: IToken, params?: IQuery): Promise<IOrderResult>
@@ -83,8 +217,40 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.checkoutCompletePath(), token, params)
   }
 
+  /**
+   * Adds Store Credit payments if a user has any. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1OA-add-store-credit).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   amount: number
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.addStoreCredits({
+   *   bearer_token: '7381273269536713689562374856',
+   *   amount: 100
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.addStoreCredits({
+   *   order_token: '7381273269536713689562374856',
+   *   amount: 100
+   * })
+   * ```
+   */
   public async addStoreCredits(options: AddStoreCreditOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async addStoreCredits(token: IToken, params: AddStoreCredit): Promise<IOrderResult>
@@ -95,8 +261,31 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('post', routes.checkoutAddStoreCreditsPath(), token, params)
   }
 
+  /**
+   * Remove Store Credit payments if any applied. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc1OQ-remove-store-credit).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.removeStoreCredits({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.removeStoreCredits({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async removeStoreCredits(options: RemoveStoreCreditsOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeStoreCredits(token: IToken, params?: IQuery): Promise<IOrderResult>
@@ -107,8 +296,31 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('post', routes.checkoutRemoveStoreCreditsPath(), token, params)
   }
 
+  /**
+   * Returns a list of available Payment Methods. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc2MA-list-payment-methods).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.paymentMethods({
+   *   bearer_token: '7381273269536713689562374856'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.paymentMethods({
+   *   order_token: '7381273269536713689562374856'
+   * })
+   * ```
+   */
   public async paymentMethods(options: PaymentMethodsOptions): Promise<IPaymentMethodsResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async paymentMethods(token: IToken): Promise<IPaymentMethodsResult>
@@ -120,14 +332,40 @@ export default class Checkout extends Http {
   }
 
   /**
+   * @hidden
    * @deprecated Use {@link shippingRates} instead.
    */
   public async shippingMethods(token: IToken, params: IQuery = {}): Promise<IShippingMethodsResult> {
     return await this.spreeResponse<IShippingMethods>('get', routes.checkoutShippingMethodsPath(), token, params)
   }
 
+  /**
+   * Returns a list of available Shipping Rates for Checkout. Shipping Rates are grouped against Shipments. Each checkout cna have multiple Shipments eg. some products are available in stock and will be send out instantly and some needs to be backordered. See [api docs](https://api.spreecommerce.org/docs/api-v2/ed60ec67b7d90-list-shipping-rates).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   * const response = await client.checkout.shippingRates({
+   *   bearer_token: '7381273269536713689562374856',
+   *   include: 'shipping_rates,stock_location'
+   * })
+   *
+   * // or guest user
+   * const response = await client.checkout.shippingRates({
+   *   order_token: '7381273269536713689562374856',
+   *   include: 'shipping_rates,stock_location'
+   * })
+   * ```
+   */
   public async shippingRates(options: ShippingRatesOptions): Promise<ShippingRatesResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async shippingRates(token: IToken, params?: IQuery): Promise<ShippingRatesResult>
@@ -138,8 +376,34 @@ export default class Checkout extends Http {
     return await this.spreeResponse<ShippingRates>('get', routes.checkoutShippingRatesPath(), token, params)
   }
 
+  /**
+   * Selects a Shipping Method for Shipment(s). See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjY1NTc1NzY-selects-shipping-method-for-shipment-s).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   shipping_method_id: string
+   *   shipment_id?: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.checkout.selectShippingMethod({
+   *   bearer_token: '7381273269536713689562374856',
+   *   shipping_method_id: '42'
+   * })
+   * ```
+   */
   public async selectShippingMethod(options: SelectShippingMethodOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async selectShippingMethod(token: IToken, params: SelectShippingMethod): Promise<IOrderResult>
@@ -150,8 +414,77 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('patch', routes.checkoutSelectShippingMethodPath(), token, params)
   }
 
+  /**
+   * Creates new Payment for the current checkout. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjYyODA2NTY-create-new-payment).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   payment_method_id: string
+   *   source_id?: string
+   *   amount?: number
+   *   source_attributes?: {
+   *     gateway_payment_profile_id: string
+   *     cc_type?: string
+   *     last_digits?: string
+   *     month?: string
+   *     year?: string
+   *     name: string
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Logged in user
+   *
+   * // Create new credit card
+   * const response = await client.checkout.addPayment({
+   *   bearer_token: '7381273269536713689562374856',
+   *   payment_method_id: '1',
+   *   source_attributes: {
+   *     gateway_payment_profile_id: 'card_1JqvNB2eZvKYlo2C5OlqLV7S',
+   *     cc_type: 'visa',
+   *     last_digits: '1111',
+   *     month: '10',
+   *     year: '2026',
+   *     name: 'John Snow'
+   *   }
+   * })
+   *
+   * // Use existing credit card
+   * const response = await client.checkout.addPayment({
+   *   bearer_token: '7381273269536713689562374856',
+   *   payment_method_id: '1',
+   *   source_id: '1'
+   * })
+   *
+   * // or guest user
+   *
+   * // Create new credit card
+   * const response = await client.checkout.addPayment({
+   *   order_token: '7381273269536713689562374856',
+   *   payment_method_id: '1',
+   *   source_attributes: {
+   *     gateway_payment_profile_id: 'card_1JqvNB2eZvKYlo2C5OlqLV7S',
+   *     cc_type: 'visa',
+   *     last_digits: '1111',
+   *     month: '10',
+   *     year: '2026',
+   *     name: 'John Snow'
+   *   }
+   * })
+   * ```
+   */
   public async addPayment(options: AddPaymentOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async addPayment(token: IToken, addPaymentParams: AddPayment): Promise<IOrderResult>
@@ -162,6 +495,9 @@ export default class Checkout extends Http {
     return await this.spreeResponse<IOrder>('post', routes.checkoutAddPaymentPath(), token, params)
   }
 
+  /**
+   * @hidden
+   */
   public async createStripeSession(options: CreateStripeSessionOptions): Promise<StripeCheckoutSessionSummaryResult> {
     const { token, params } = squashAndPreparePositionalArguments([options], [])
 

--- a/packages/sdk-core/src/endpoints/Countries.ts
+++ b/packages/sdk-core/src/endpoints/Countries.ts
@@ -13,14 +13,48 @@ import type { IQuery } from '../interfaces/Query'
 import routes from '../routes'
 
 export default class Countries extends Http {
+  /**
+   * Returns a list of all countries. See [api docs](https://api.spreecommerce.org/docs/api-v2/ca56911efbaab-list-all-countries).
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const countries = await client.countries.list()
+   * ```
+   */
   public async list(options?: ListOptions): Promise<ICountriesResult> {
     const { token, params } = squashAndPreparePositionalArguments([options || {}], [])
 
     return await this.spreeResponse<ICountries>('get', routes.countriesPath(), token, params)
   }
 
+  /**
+   * Returns the details of a specific country. See [api docs](https://api.spreecommerce.org/docs/api-v2/5f5116adb3113-retrieve-a-country).
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   iso: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const country = await client.countries.show({
+   *   iso: 'USA'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<ICountryResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(iso: string, params: IQuery): Promise<ICountryResult>
@@ -34,8 +68,21 @@ export default class Countries extends Http {
     return await this.spreeResponse<ICountry>('get', routes.countryPath(iso), token, params)
   }
 
+  /**
+   * Returns the default country for the current store. By default this will be the US. See [api docs](https://api.spreecommerce.org/docs/api-v2/7cf807c85c035-get-default-country).
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const countries = await client.countries.default()
+   * ```
+   */
   public async default(options?: DefaultOptions): Promise<ICountryResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async default(params: IQuery): Promise<ICountryResult>

--- a/packages/sdk-core/src/endpoints/DigitalAssets.ts
+++ b/packages/sdk-core/src/endpoints/DigitalAssets.ts
@@ -6,8 +6,52 @@ import type { DigitalAsset, DigitalAssetResult, DownloadOptions } from '../inter
 import squashAndPreparePositionalArguments from '../helpers/squashAndPreparePositionalArguments'
 
 export default class DigitalAssets extends Http {
+  /**
+   * Returns a stream for downloading a purchased digital product. See [api docs](https://api.spreecommerce.org/docs/api-v2/da2a29db89559-download-a-digital-asset).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) or [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   asset_token: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * // Many NodeJS servers allow piping a stream as the response (`digitalAssetStream.pipe(serverResponse);`).
+   *
+   * // The below example assumes a logged in user using SpreeSDK in the browser and downloading an image asset.
+   *
+   * // A digital token can be retrieved from a digital link associated to a line item in a completed order.
+   * const digitalToken = '1YjXK36ZRj2w4nxtMkJutTGX'
+   *
+   * const response = await client.digitalAssets.download({
+   *   bearer_token: '7381273269536713689562374856',
+   *   asset_token: digitalToken
+   * })
+   *
+   * const digitalAssetStream = response.success()
+   *
+   * // Append an <img> tag to the page to show the asset on the page.
+   * const image = new Image()
+   *
+   * document.body.appendChild(image)
+   *
+   * // Convert a stream to a Blob for easier processing.
+   * const digitalAssetBlob = await new Response(digitalAssetStream).blob()
+   *
+   * image.src = URL.createObjectURL(digitalAssetBlob)
+   * ```
+   */
   public async download(options: DownloadOptions): Promise<DigitalAssetResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async download(token: IToken, assetToken: string, params?: IQuery): Promise<DigitalAssetResult>

--- a/packages/sdk-core/src/endpoints/Menus.ts
+++ b/packages/sdk-core/src/endpoints/Menus.ts
@@ -13,8 +13,36 @@ import type { IQuery } from '../interfaces/Query'
 import routes from '../routes'
 
 export default class Menus extends Http {
+  /**
+   * Returns a list of Menus. See [api docs](https://api.spreecommerce.org/docs/api-v2/1021e86f10cee-list-all-menus).
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   locale?: string
+   *   filter?: {
+   *     location?: string
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.menus.list({
+   *   locale: 'fr',
+   *   filter: {
+   *     location: 'header'
+   *   }
+   * })
+   * ```
+   */
   public async list(options?: ListOptions): Promise<MenusResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async list(params?: MenusList): Promise<MenusResult>
@@ -25,8 +53,30 @@ export default class Menus extends Http {
     return await this.spreeResponse<MenusResponse>('get', routes.menusPath(), token, params)
   }
 
+  /**
+   * Returns a single Menu. See [api docs](https://api.spreecommerce.org/docs/api-v2/b67d067a42bc5-retrieve-a-menu).
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.menus.show({
+   *   id: '2'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<MenuResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(id: string, params?: IQuery): Promise<MenuResult>

--- a/packages/sdk-core/src/endpoints/Order.ts
+++ b/packages/sdk-core/src/endpoints/Order.ts
@@ -6,8 +6,33 @@ import type { IToken } from '../interfaces/Token'
 import routes from '../routes'
 
 export default class Order extends Http {
+  /**
+   * Returns a placed Order.
+   * 
+   * **Required token:** [Order token](../pages/tokens.html#order-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   order_number: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.order.status({
+   *   order_token: '7381273269536713689562374856',
+   *   order_number: 'R653163382'
+   * })
+   * ```
+   */
   public async status(options: StatusOptions): Promise<IOrderResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async status(token: IToken, orderNumber: string, params?: IQuery): Promise<IOrderResult>

--- a/packages/sdk-core/src/endpoints/Pages.ts
+++ b/packages/sdk-core/src/endpoints/Pages.ts
@@ -5,8 +5,21 @@ import type { IQuery } from '../interfaces/Query'
 import routes from '../routes'
 
 export default class Pages extends Http {
+  /**
+   * Returns a list of all CMS Pages available in the current store. See [api docs](https://api.spreecommerce.org/docs/api-v2/48dab6913cd0d-list-all-cms-pages).
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const pages = await client.pages.list()
+   * ```
+   */
   public async list(options?: ListOptions): Promise<IPagesResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async list(params?: IQuery): Promise<IPagesResult>
@@ -17,8 +30,30 @@ export default class Pages extends Http {
     return await this.spreeResponse<IPages>('get', routes.pagesPath(), token, params)
   }
 
+  /**
+   * Returns a single CMS Page. You can use either a CMS Page slug or ID. See [api docs](https://api.spreecommerce.org/docs/api-v2/cedb218a94c4d-retrieve-a-cms-page).
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const page = await client.pages.show({
+   *   id: 'about-us'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<IPageResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(id: string, params?: IQuery): Promise<IPageResult>

--- a/packages/sdk-core/src/endpoints/Products.ts
+++ b/packages/sdk-core/src/endpoints/Products.ts
@@ -13,8 +13,36 @@ import type { IToken } from '../interfaces/Token'
 import routes from '../routes'
 
 export default class Products extends Http {
+  /**
+   * Returns a list of Products. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc2Mg-list-all-products).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) - if logged in user
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   image_transformation?: {
+   *     size?: string
+   *     quality?: number
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.products.list({
+   *   page: 1,
+   *   per_page: 10
+   * })
+   * ```
+   */
   public async list(options: ListOptions): Promise<IProductsResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async list(token: IToken, params: IProductsQuery): Promise<IProductsResult>
@@ -25,8 +53,36 @@ export default class Products extends Http {
     return await this.spreeResponse<IProducts>('get', routes.productsPath(), token, params)
   }
 
+  /**
+   * Returns a single product. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MTgwNTI4ODE-retrieve-a-product).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token) - if logged in user
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   image_transformation?: {
+   *     size?: string
+   *     quality?: number
+   *   }
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.products.show({
+   *   id: '123',
+   *   include: 'variants'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<IProductResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(id: string, token: IToken, params: IProductsQuery): Promise<IProductResult>

--- a/packages/sdk-core/src/endpoints/Taxons.ts
+++ b/packages/sdk-core/src/endpoints/Taxons.ts
@@ -5,8 +5,21 @@ import type { ITaxon, ITaxonResult, ITaxons, ITaxonsResult, ListOptions, ShowOpt
 import routes from '../routes'
 
 export default class Taxons extends Http {
+  /**
+   * Returns a list of Taxons. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MzE0Mjc2NA-list-all-taxons).
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.taxons.list()
+   * ```
+   */
   public async list(options?: ListOptions): Promise<ITaxonsResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async list(params?: IQuery): Promise<ITaxonsResult>
@@ -17,8 +30,28 @@ export default class Taxons extends Http {
     return await this.spreeResponse<ITaxons>('get', routes.taxonsPath(), token, params)
   }
 
+  /**
+   * Returns a single Taxon. See [api docs](https://api.spreecommerce.org/docs/api-v2/6e26f7594be8b-retrieve-a-taxon).
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const products = await client.taxons.show({ id: '1' })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<ITaxonResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(id: string, params?: IQuery): Promise<ITaxonResult>

--- a/packages/sdk-core/src/endpoints/Vendors.ts
+++ b/packages/sdk-core/src/endpoints/Vendors.ts
@@ -10,13 +10,49 @@ import type {
 } from '../interfaces/Vendor'
 import routes from '../routes'
 
+/**
+ * The multi-vendor marketplace feature is only available via [Vendo](https://www.getvendo.com).
+ */
 export default class Vendors extends Http {
+  /**
+   * Returns a list of Vendors in a Spree marketplace.
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const vendors = await client.vendors.list({
+   *   include: 'products'
+   * })
+   * ```
+   */
   public async list(options: ListOptions = {}): Promise<VendorsResult> {
     const { token, params } = squashAndPreparePositionalArguments([options], [])
 
     return await this.spreeResponse<VendorsType>('get', routes.vendorsPath(), token, params)
   }
 
+  /**
+   * Returns a single Vendor in a Spree marketplace.
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const vendor = await client.vendors.show({ id: '123' })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<VendorResult> {
     const { id, token, params } = squashAndPreparePositionalArguments([options], ['id'])
 

--- a/packages/sdk-core/src/endpoints/Wishlists.ts
+++ b/packages/sdk-core/src/endpoints/Wishlists.ts
@@ -31,8 +31,33 @@ import type {
 import routes from '../routes'
 
 export default class Wishlists extends Http {
+  /**
+   * Returns a list of Wishlists. See [api docs](https://api.spreecommerce.org/docs/api-v2/2b6c6c347d14b-list-all-wishlists).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   is_variant_included?: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.list({
+   *   bearer_token: '7381273269536713689562374856',
+   *   is_variant_included: '456'
+   * })
+   * ```
+   */
   public async list(options: ListOptions): Promise<WishlistsResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async list(token: IToken, params?: WishlistsList): Promise<WishlistsResult>
@@ -43,8 +68,35 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<WishlistsResponse>('get', routes.wishlistsPath(), token, params)
   }
 
+  /**
+   * Returns a single Wishlist. See [api docs](https://api.spreecommerce.org/docs/api-v2/b3A6MjE0NTY5NDA-retrieve-a-wishlist).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string
+   *   is_variant_included?: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.show({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: '123',
+   *   is_variant_included: '456'
+   * })
+   * ```
+   */
   public async show(options: ShowOptions): Promise<WishlistResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async show(token: IToken, wishlistToken: string, params?: WishlistsShow): Promise<WishlistResult>
@@ -58,8 +110,33 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<WishlistResponse>('get', routes.wishlistPath(wishlist_token), token, params)
   }
 
+  /**
+   * Returns the default Wishlist for the logged in user. It will be created, if the user does not have a default Wishlist for the current store. See [api docs](https://api.spreecommerce.org/docs/api-v2/f29e11140c53c-retrieve-the-default-wishlist).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   is_variant_included?: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.default({
+   *   bearer_token: '7381273269536713689562374856',
+   *   is_variant_included: '456'
+   * })
+   * ```
+   */
   public async default(options: DefaultOptions): Promise<WishlistResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async default(token: IToken, params?: WishlistsDefault): Promise<WishlistResult>
@@ -70,8 +147,35 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<WishlistResponse>('get', routes.defaultWishlistPath(), token, params)
   }
 
+  /**
+   * Creates a new Wishlist for the logged in user.
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   name: string
+   *   is_private?: boolean
+   *   is_default?: boolean
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.create({
+   *   bearer_token: '7381273269536713689562374856',
+   *   name: 'My wishlist'
+   * })
+   * ```
+   */
   public async create(options: CreateOptions): Promise<WishlistResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async create(token: IToken, params: WishlistsCreate): Promise<WishlistResult>
@@ -82,8 +186,38 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<WishlistResponse>('post', routes.wishlistsPath(), token, params)
   }
 
+  /**
+   * Updates an existing Wishlist.
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string
+   *   name: string
+   *   is_private?: boolean
+   *   is_default?: boolean
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.update({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: '123',
+   *   name: 'My updated wishlist',
+   *   is_private: true
+   * })
+   * ```
+   */
   public async update(options: UpdateOptions): Promise<WishlistResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async update(token: IToken, wishlistToken: string, params: WishlistsUpdate): Promise<WishlistResult>
@@ -97,8 +231,33 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<WishlistResponse>('patch', routes.wishlistPath(wishlist_token), token, params)
   }
 
+  /**
+   * Removes a Wishlist. See [api docs](https://api.spreecommerce.org/docs/api-v2/74e84b03b47e0-delete-a-wishlist).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.remove({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: '123'
+   * })
+   * ```
+   */
   public async remove(options: RemoveOptions): Promise<NoContentResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async remove(token: IToken, wishlistToken: string): Promise<NoContentResult>
@@ -112,8 +271,37 @@ export default class Wishlists extends Http {
     return await this.spreeResponse<NoContentResponse>('delete', routes.wishlistPath(wishlist_token), token, params)
   }
 
+  /**
+   * Adds a new Wished Item to a Wishlist for the logged in user. See [api docs](https://api.spreecommerce.org/docs/api-v2/486219cd63ea9-add-item-to-wishlist).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string,
+   *   variant_id: string
+   *   quantity: number
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.addWishedItem({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: 'WyZxWS2w3BdDRHcGgtN1LKiY',
+   *   variant_id: '1',
+   *   quantity: 10
+   * })
+   * ```
+   */
   public async addWishedItem(options: AddWishedItemOptions): Promise<WishedItemResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async addWishedItem(
@@ -136,8 +324,37 @@ export default class Wishlists extends Http {
     )
   }
 
+  /**
+   * Updates a Wished Item for the logged in user. See [api docs](https://api.spreecommerce.org/docs/api-v2/e6e478e46003d-set-wished-item-quantity).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string,
+   *   id: string
+   *   quantity: number
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.updateWishedItem({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: 'WyZxWS2w3BdDRHcGgtN1LKiY',
+   *   id: '2',
+   *   quantity: 13
+   * })
+   * ```
+   */
   public async updateWishedItem(options: UpdateWishedItemOptions): Promise<WishedItemResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async updateWishedItem(
@@ -161,8 +378,35 @@ export default class Wishlists extends Http {
     )
   }
 
+  /**
+   * Removes a Wished Item for the logged in user. See [api docs](https://api.spreecommerce.org/docs/api-v2/766b11755bbb0-delete-item-from-wishlist).
+   * 
+   * **Required token:** [Bearer token](../pages/tokens.html#bearer-token)
+   * 
+   * **Options schema:**
+   * ```ts
+   * interface options {
+   *   wishlist_token: string,
+   *   id: string
+   * }
+   * ```
+   * 
+   * **Success response schema:** [Success schema](../pages/response-schema.html#success-schema)
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const response = await client.wishlists.removeWishedItem({
+   *   bearer_token: '7381273269536713689562374856',
+   *   wishlist_token: 'WyZxWS2w3BdDRHcGgtN1LKiY',
+   *   id: '2'
+   * })
+   * ```
+   */
   public async removeWishedItem(options: RemoveWishedItemOptions): Promise<WishedItemResult>
   /**
+   * @hidden
    * @deprecated Use the combined options signature instead.
    */
   public async removeWishedItem(token: IToken, wishlistToken: string, id: string): Promise<WishedItemResult>

--- a/packages/sdk-fetcher-axios/README.md
+++ b/packages/sdk-fetcher-axios/README.md
@@ -1,0 +1,37 @@
+**Spree SDK in NodeJS using Axios**
+
+To use Spree SDK with Axios in NodeJS, install Axios along with the fetcher using NPM:
+
+```
+npm install @spree/storefront-api-v2-sdk-axios axios
+```
+
+Set the fetcher to axios when creating the Spree SDK client:
+
+```js
+const createAxiosFetcher = require('@spree/storefront-api-v2-sdk-axios/dist/server/index').default
+const { makeClient } = require('@spree/storefront-api-v2-sdk')
+const client = makeClient({
+  host: 'http://localhost:3000',
+  createFetcher: createAxiosFetcher
+})
+```
+
+**Spree SDK in the browser using Axios**
+
+To use Spree SDK with Axios in the browser, include axios as a `<script>` tag before using the SDK:
+
+```html
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk@6.0.0/dist/client/index.js"></script>
+<script src="https://unpkg.com/axios@0.24.0/dist/axios.min.js"></script>
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk-axios@1.0.0/dist/client/index.js"></script>
+
+<script>
+  const client = SpreeSDK.makeClient({
+    host: 'http://localhost:3000',
+    createFetcher: SpreeSDK.createAxiosFetcher.default
+  })
+</script>
+```
+
+Spree SDK will automatically detect that Axios is available and use it to make requests to Spree.

--- a/packages/sdk-fetcher-axios/package.json
+++ b/packages/sdk-fetcher-axios/package.json
@@ -27,5 +27,8 @@
   "sideEffects": false,
   "peerDependencies": {
     "axios": "^0.25.0"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
   }
 }

--- a/packages/sdk-fetcher-node-fetch/README.md
+++ b/packages/sdk-fetcher-node-fetch/README.md
@@ -1,0 +1,34 @@
+**Spree SDK in NodeJS using fetch**
+
+To use Spree SDK with [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) in NodeJS, install Node Fetch along with the fetcher using NPM:
+
+```
+npm install @spree/storefront-api-v2-sdk-node-fetch node-fetch
+```
+
+Set the fetcher to fetch:
+
+```js
+const createFetchFetcher = require('@spree/storefront-api-v2-sdk-node-fetch/dist/server/index').default
+const { makeClient } = require('@spree/storefront-api-v2-sdk')
+const client = makeClient({
+  host: 'http://localhost:3000',
+  createFetcher: createFetchFetcher
+})
+```
+
+**Spree SDK in the browser using fetch**
+
+Modern web browsers include fetch natively. To use Spree SDK with native fetch, it's enough to set `fetcherType` to `'fetch'` when creating the Spree SDK Client:
+
+```html
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk@6.0.0/dist/client/index.js"></script>
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk-node-fetch@1.0.0/dist/client/index.js"></script>
+
+<script>
+  const client = SpreeSDK.makeClient({
+    host: 'http://localhost:3000',
+    createFetcher: SpreeSDK.createFetchFetcher.default
+  })
+</script>
+```

--- a/packages/sdk-fetcher-node-fetch/package.json
+++ b/packages/sdk-fetcher-node-fetch/package.json
@@ -27,6 +27,9 @@
   "sideEffects": false,
   "peerDependencies": {
     "node-fetch": "^2.6.6"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
   }
 }
   

--- a/pages/alternative-setups.md
+++ b/pages/alternative-setups.md
@@ -1,0 +1,29 @@
+## TypeScript and `import`
+
+In TypeScript, you can import Spree SDK as follows:
+
+```js
+// Set `"esModuleInterop": true` in tsconfig.json
+import createAxiosFetcher from '@spree/storefront-api-v2-sdk-axios/dist/server'
+import { makeClient } from '@spree/storefront-api-v2-sdk'
+```
+
+TypeScript definitions are included in the module and should be automatically used by any editor that supports them.
+
+## CDN-hosted Spree SDK
+
+The SDK is hosted by the [UNPKG](https://unpkg.com/) CDN. [Follow this link to download version 6.0.0](https://unpkg.com/@spree/storefront-api-v2-sdk@6.0.0/dist/client/index.js) and [this link to download the newest version](https://unpkg.com/@spree/storefront-api-v2-sdk/dist/client/index.js). Include the SDK on a website like so:
+
+```html
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk@6.0.0/dist/client/index.js"></script>
+<script src="https://unpkg.com/axios@0.24.0/dist/axios.min.js"></script>
+<script src="https://unpkg.com/@spree/storefront-api-v2-sdk-axios@1.0.0/dist/client/index.js"></script>
+
+<script>
+  const client = SpreeSDK.makeClient({
+    host: 'http://localhost:3000',
+    createFetcher: SpreeSDK.createAxiosFetcher.default
+  })
+  // ...
+</script>
+```

--- a/pages/checkout-flow.md
+++ b/pages/checkout-flow.md
@@ -1,0 +1,47 @@
+```ts
+const cartCreateResponse = await client.cart.create()
+const orderToken = cartCreateResponse.success().data.attributes.token
+await client.cart.addItem({
+  order_token: orderToken,
+  variant_id: '1'
+})
+// Step one - save email, billing and shipping addresses
+await client.checkout.orderUpdate({
+  order_token: orderToken,
+  order: {
+    email,
+    bill_address_attributes: {...},
+    ship_address_attributes: {...}
+  }
+})
+await client.checkout.orderNext({ order_token: orderToken })
+// Step two - pick a shipping method
+const shipping = (await client.checkout.shippingRates({ order_token: orderToken })).success()
+await client.checkout.orderUpdate({
+  order_token: orderToken,
+  order: {
+    shipments_attributes: [{
+      id: shipping.data[0].id,
+      selected_shipping_rate_id: shipping.data[0].relationships.shipping_rates.data[0].id
+    }]
+  }
+})
+await client.checkout.orderNext({ order_token: orderToken })
+// Step three - pick a payment method
+const payment = (await client.checkout.paymentMethods({ order_token: orderToken })).success()
+await client.checkout.addPayment({
+  order_token: orderToken,
+  payment_method_id: payment.data[0].id,
+  source_attributes: {
+    gateway_payment_profile_id: "card_1JqvNB2eZvKYlo2C5OlqLV7S",
+    cc_type: "visa",
+    last_digits: "1111",
+    month: "10",
+    year: "2026",
+    name: "John Snow"
+  }
+})
+await client.checkout.orderNext({ order_token: orderToken })
+// Place the order
+await client.checkout.complete({ order_token: orderToken })
+```

--- a/pages/helpers.md
+++ b/pages/helpers.md
@@ -1,0 +1,31 @@
+The SDK comes with a number of helper functions making consuming responses from the Spree API easier.
+
+`extractSuccess()` unwraps Spree responses and throws errors.
+
+**Example:**
+
+```ts
+import { result } from '@spree/storefront-api-v2-sdk'
+try {
+  const cartResponse = await result.extractSuccess(client.cart.create())
+  console.log('Created a new cart having token: ', cartResponse.data.attributes.token)
+} catch (error) {
+  console.error('Creating a cart failed. Reason: ', error)
+}
+```
+
+`findRelationshipDocuments()` finds related records included in a response and `findSingleRelationshipDocument()` finds a single included record.
+
+**Example:**
+
+```ts
+import { jsonApi } from '@spree/storefront-api-v2-sdk'
+const productResult = await client.products.show({
+  id: '1',
+  include: 'primary_variant,variants,images'
+})
+const productResponse = productResult.success()
+const primaryVariant = jsonApi.findSingleRelationshipDocument(productResponse, productResponse.data, 'primary_variant')
+const variants = jsonApi.findRelationshipDocuments(productResponse, productResponse.data, 'variants')
+const images = jsonApi.findRelationshipDocuments(productResponse, productResponse.data, 'images')
+```

--- a/pages/quick-start.md
+++ b/pages/quick-start.md
@@ -1,0 +1,37 @@
+Install the NPM package:
+
+```
+npm install --save @spree/storefront-api-v2-sdk
+```
+
+Install the [Node Fetch](https://www.npmjs.com/package/node-fetch) HTTP client and the Node Fetch fetcher to be able to use it:
+
+```
+npm install --save @spree/storefront-api-v2-sdk-node-fetch node-fetch
+```
+
+_If you want to use the Spree SDK for a browser implementation you can use the native fetch without the need to install anything ([see here](../modules/_spree_storefront_api_v2_sdk_node_fetch.html))._
+
+Create a client and use it to call Spree:
+
+```js
+const createAxiosFetcher = require('@spree/storefront-api-v2-sdk-node-fetch/dist/server/index').default
+const { makeClient } = require('@spree/storefront-api-v2-sdk')
+const client = makeClient({
+  host: 'http://localhost:3000',
+  createFetcher: createAxiosFetcher
+})
+
+client.products
+  .list({
+    include: 'default_variant',
+    page: 1
+  })
+  .then((spreeResponse) => {
+    console.log(spreeResponse.success())
+  })
+```
+
+_Spree SDK can also be imported using `import` and `<script>` tags in the browser. Check the {@page alternative-setups.md} section for examples._
+
+_For details about HTTP clients, read the {@page switching-the-fetcher.md} section._

--- a/pages/response-schema.md
+++ b/pages/response-schema.md
@@ -1,0 +1,21 @@
+## Success schema
+
+`Client` methods return a result object. When a request succeeds, the data received from Spree is retrievable using its `success()` method and provided in the [JSON:API](https://jsonapi.org/format/) format. `isSuccess()` tells if a request succeeded.
+
+## Error schema
+
+The SDK avoids throwing JavaScript [`Errors`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error). Instead, any error is included in a result object.
+
+To determine whether a call was successful, use `isSuccess()` or `isFail()` methods on the result. Details of a failed call can be retrieved using `fail()`. The method returns a `SpreeSDKError` instance, which is the primary type for all errors returned by the SDK and extends the native JavaScript `Error` type.
+
+Available `SpreeSDKError` subtypes:
+
+| Class Name              | Purpose                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `MisconfigurationError` | Signifies the SDK's `Client` was created with improper options. Make sure the values of `host` and other options (if any) provided to `Client` have the correct format.                                                                                                                                                                    |
+| `NoResponseError`       | Spree store could not be reached. Ensure it's running and available under the `host` address provided to the `Client` instance.                                                                                                                                                                                                            |
+| `SpreeError`            | Spree responded with an error. To debug the issue, check the error's `serverResponse` field. It contains details about the response from Spree, such as the HTTP status code and headers.                                                                                                                                                  |
+| `BasicSpreeError`       | Extends `SpreeError` with a `summary` field provided by Spree and containing a summary of the issue.                                                                                                                                                                                                                                       |
+| `ExpandedSpreeError`    | Extends `BasicSpreeError` with a `errors` field. `errors` contains a detailed explanation of the issue, ex. all the validation errors when trying to add shipping details to a Spree order. The `getErrors` method can be used to retrieve a concrete value inside `errors`, ex. `expSpreeError.getErrors(['bill_address', 'firstname'])`. |
+
+The specific type of error returned by `fail()` can be determined using [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof), ex. `if(response.fail() instanceof BasicSpreeError){...}`.

--- a/pages/switching-the-fetcher.md
+++ b/pages/switching-the-fetcher.md
@@ -1,0 +1,13 @@
+Spree SDK does not come bundled with a HTTP client. A HTTP client may have to be installed before using the library. Out of the box, Spree SDK supports using [Axios](https://github.com/axios/axios) and [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) HTTP clients to communicate with Spree. To use one of them you have to install and configure a corresponding package:
+- [Node fetch](../modules/_spree_storefront_api_v2_sdk_node_fetch.html) (recommended)
+- [Axios](../modules/_spree_storefront_api_v2_sdk_axios.html)
+
+**ADVANCED: Supply a custom HTTP client.**
+
+To have full control over requests and responses, a custom fetcher can be supplied during the creation of the Spree SDK client:
+
+```js
+makeClient({ createFetcher: ... })
+```
+
+If you want to use a fetch-compatible interface, use the `createCustomizedFetchFetcher` function.

--- a/pages/tokens.md
+++ b/pages/tokens.md
@@ -1,0 +1,26 @@
+Most endpoints require a token for authentication. It can be an Order Token, Bearer Token or a Confirmation Token.
+
+## Order token
+
+Identifies a guest user's cart and order. {@page response-schema.md}
+
+```ts
+const response = await client.cart.create()
+const orderToken: string = response.success().data.attributes.token
+```
+
+## Bearer token
+
+Identifies a logged in user.
+
+```ts
+const response = await client.authentication.getToken({
+  username: 'spree@example.com',
+  password: 'spree123'
+})
+const bearerToken: string = response.success().access_token
+```
+
+## Confirmation token
+
+Identifies a user for a single operation. For example, to reset their account's password. Confirmation Tokens are single-use and may have an expiration date.

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,41 @@
+{
+  "name": "Spree SDK packages",
+  "entryPointStrategy": "packages",
+  "entryPoints": [
+    "packages/sdk-core",
+    "packages/sdk-fetcher-node-fetch",
+    "packages/sdk-fetcher-axios"
+  ],
+  "out": "docs",
+  "sort": ["static-first"],
+  "disableSources": true,
+  "pluginPages": {
+    "pages": [
+      {
+        "title": "Spree SDK packages",
+        "moduleRoot": true,
+        "children": [
+          { "title": "Quick start", "source": "quick-start.md" },
+          { "title": "Checkout flow", "source": "checkout-flow.md" },
+          { "title": "Response schema", "source": "response-schema.md" },
+          { "title": "Tokens", "source": "tokens.md" },
+          { "title": "Helpers", "source": "helpers.md" },
+          { "title": "Alternative setups", "source": "alternative-setups.md" },
+          { "title": "Switching the fetcher", "source": "switching-the-fetcher.md" }
+        ]
+      },
+      {
+        "title": "@spree/storefront-api-v2-sdk",
+        "moduleRoot": true
+      },
+      {
+        "title": "@spree/storefront-api-v2-sdk-axios",
+        "moduleRoot": true
+      },
+      {
+        "title": "@spree/storefront-api-v2-sdk-node-fetch",
+        "moduleRoot": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds typedoc configuration for the SDK monorepo. All the SDK endpoints now have their documentation reference defined as a comment right before the function definition. Apart from that docs examples are updated with the new `6.0.0` SDK version that has to be released due to breaking changes.

Documentation demo: https://storefront-sdk-docs.web.app/index.html